### PR TITLE
docs: remove "--no-wallet" for `balanceOf` API

### DIFF
--- a/docs/xtc/getting-started.md
+++ b/docs/xtc/getting-started.md
@@ -163,7 +163,7 @@ This query calls don't require a fee since they only query information.
 Returns the balance of user `who`.
 
 ```bash
-dfx canister --network=ic --no-wallet call --query aanaa-xaaaa-aaaah-aaeiq-cai balanceOf "(principal \"who-account-principal\")"
+dfx canister --network=ic call --query aanaa-xaaaa-aaaah-aaeiq-cai balanceOf "(principal \"who-account-principal\")"
 ```
 
 ### Check the set allowance for an ID - allowance


### PR DESCRIPTION
`--no-wallet` has been deprected on modern dfx canister `call` method. More details [here](https://internetcomputer.org/docs/current/references/cli-reference/dfx-canister#dfx-canister-call)