### PR TITLE
docs: remove "--no-wallet" for `burn` API and format for easy copyabi…

### DIFF
--- a/docs/xtc/getting-started.md
+++ b/docs/xtc/getting-started.md
@@ -91,10 +91,10 @@ dfx canister --network ic call aanaa-xaaaa-aaaah-aaeiq-cai mint_by_icp "(null,$B
 ### Withdrawing cycles to a Canister - Burn
 
 Unwraps Cycles Token (XTC) into raw Cycles to send them to a Canister ID. (You should change the amount)
+TIP: When sending your entire XTC balance to a canister, reserve 2 billion XTC cycles to get burned as transaction fees and send the rest
 
 ```bash
-$ dfx canister --network=ic --no-wallet call aanaa-xaaaa-aaaah-aaeiq-cai burn "(record { canister_id= principal \"some-canister's-principal-id\"; amount= (2000:nat64)})"
-(variant { Ok = 1 })
+dfx canister --network=ic --no-wallet call aanaa-xaaaa-aaaah-aaeiq-cai burn "(record { canister_id= principal \"some-canister's-principal-id\"; amount= (2000:nat64)})"
 ```
 
 ---


### PR DESCRIPTION
- `--no-wallet` has been deprected on modern dfx canister `call` method. More details [here](https://internetcomputer.org/docs/current/references/cli-reference/dfx-canister#dfx-canister-call)
- Add a tip for when sending your entire XTC cycle balance
- Remove the leading "$" for easy copy-paste to the terminal as otherwise detected as invalid command by bash
- Remove the API response for easy copy-paste to the terminal as the newline would make the command execute immediately and the output would get copied as the next command to the terminal
- Remove the output altogether because the output display format has changed and doesn't match the current content in the docs